### PR TITLE
Add pre-commit hooks for contributors.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = cartopy,climpred,matplotlib,numpy,scipy,setuptools,shapely,tqdm,xarray

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.2.3
+      hooks:
+      -   id: trailing-whitespace
+      -   id: end-of-file-fixer
+      -   id: check-docstring-first
+      -   id: check-yaml
+      -   id: double-quote-string-fixer
+      -   id: flake8
+
+  -   repo: https://github.com/ambv/black
+      rev: 19.3b0
+      hooks:
+      - id: black
+        args: ["--line-length", "88", "--skip-string-normalization"]
+
+  -   repo: https://github.com/asottile/seed-isort-config
+      rev: v1.9.0
+      hooks:
+      -   id: seed-isort-config
+
+  -   repo: https://github.com/pre-commit/mirrors-isort
+      rev: v4.3.20
+      hooks:
+      -   id: isort
+          args: ["-w", "88"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,17 @@ repos:
       -   id: check-docstring-first
       -   id: check-yaml
       -   id: double-quote-string-fixer
-      -   id: flake8
 
   -   repo: https://github.com/ambv/black
       rev: 19.3b0
       hooks:
       - id: black
         args: ["--line-length", "88", "--skip-string-normalization"]
+
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.2.3
+      hooks:
+      - id: flake8
 
   -   repo: https://github.com/asottile/seed-isort-config
       rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,6 @@ repos:
       - id: black
         args: ["--line-length", "88", "--skip-string-normalization"]
 
-  -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.2.3
-      hooks:
-      - id: flake8
-
   -   repo: https://github.com/asottile/seed-isort-config
       rev: v1.9.0
       hooks:
@@ -30,3 +25,9 @@ repos:
       hooks:
       -   id: isort
           args: ["-w", "88"]
+
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.2.3
+      hooks:
+      - id: flake8
+        args: ["--max-line-length=88"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# esmtools 
+# esmtools
 
 A toolbox for functions related to Earth System Model analysis, with a focus on biogeochemical oceanography.
 
@@ -12,6 +12,17 @@ pip install git+https://github.com/bradyrx/esmtools
 ```
 
 **Note**: Little development in the future will go towards visualization. We suggest [proplot](https://github.com/lukelbd/proplot) to users for a phenomenal `matplotlib` wrapper.
+
+## Contribution Guide
+
+1. Install `pre-commit` and its hook on the `esmtools` repository. Make sure you're in the main repository when you run `pre-commit install`.
+
+```bash
+$ pip install --user pre-commit
+$ pre-commit install
+```
+
+Afterwards, `pre-commit` will be run with every commit so that formatting is handled at commit-time.
 
 ## Contact
 Developed and maintained by Riley Brady.

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -16,4 +16,4 @@ dependencies:
   - cftime
   - bottleneck
   - netcdf4
-  - lxml 
+  - lxml


### PR DESCRIPTION
This adds pre-commit hooks to handle syntax issues at commit-time for contributors. This should also be implemented in `climpred` but just using this as a testbed. @aaronspring @ahuang11.

Here's a test file I tried to commit after installing `pre-commit`. (imports are out of order, formatting is weird, xr/cp not used, blank lines and whitespace at the end).

```python
import xarray as xr
import climpred as cp

def test():
    print("This is a test where I'm definitely messing up completely, with a really long string that must go past 88 characters")
    my_list = ['this', 'is',  'a', 'crazy',
               'list']
    return my_list


```

Here's my first attempt at committing. It beautifies it, and sorts the imports but fails due to flake8.

<img width="584" alt="Screen Shot 2019-05-31 at 10 40 13 AM" src="https://user-images.githubusercontent.com/8881170/58720839-8025c900-8390-11e9-93f0-389cf553994e.png">

Our hooks automatically modify the file to this:

```python
import climpred as cp
import xarray as xr


def test():
    print(
        "This is a test where I'm definitely messing up completely, with a really long string that must go past 88 characters"
    )
    my_list = ['this', 'is', 'a', 'crazy', 'list']
    return my_list
```
Although I still need to utilize the imports and manually adjust the line length under print.

I modify the `flake8` issues myself, and now I can commit the file as such:

```python
import climpred as cp
import xarray as xr


def test():
    print(
        "This is a test where I'm definitely messing up completely, with a really long "
        'string that must go past 88 characters'
    )
    my_list = ['this', 'is', 'a', 'crazy', 'list']
    xr.DataArray([1, 2, 3])
    cp.loadutils.open_dataset()
    return my_list
```