### PR TITLE
Add `fit_poly` function

### DIFF
--- a/esmtools/checks.py
+++ b/esmtools/checks.py
@@ -1,0 +1,16 @@
+from .exceptions import DimensionError
+
+
+def has_dims(xobj, dims, kind):
+    """
+    Checks that at the minimum, the object has provided dimensions.
+    """
+    if isinstance(dims, str):
+        dims = [dims]
+
+    if not all(dim in xobj.dims for dim in dims):
+        raise DimensionError(
+            f'Your {kind} object must contain the '
+            f'following dimensions at the minimum: {dims}'
+        )
+    return True

--- a/esmtools/exceptions.py
+++ b/esmtools/exceptions.py
@@ -1,0 +1,12 @@
+class Error(Exception):
+    """Base class for custom exceptions in climpred."""
+
+    pass
+
+
+class DimensionError(Error):
+    """Exception raised when the input xarray object doesn't have the
+    appropriate dimensions."""
+
+    def __init__(self, message):
+        self.message = message


### PR DESCRIPTION
This adds a `fit_poly` function which is based off of `rm_poly` from `climpred`. It simply performs the same polynomial fit, accounting for NaNs, and returns the fitted line for the time series or at each grid cell. This is useful if you want to retain some trend/polynomial line. E.g., for adding back into bootstrapping. 

This also updated `linear_regression` to allow datetime axes.

**Example**:

![Screen Shot 2019-07-03 at 5 20 15 PM](https://user-images.githubusercontent.com/8881170/60630305-d84c5280-9db6-11e9-9286-62aad824b40f.png)
