### PR TITLE
Fix Travis breakage

### DIFF
--- a/docs/source/api/esm_analysis.conversions.convert_CO2_flux.rst
+++ b/docs/source/api/esm_analysis.conversions.convert_CO2_flux.rst
@@ -1,6 +1,0 @@
-convert_CO2_flux
-================
-
-.. currentmodule:: esm_analysis.conversions
-
-.. autofunction:: convert_CO2_flux


### PR DESCRIPTION
Travis is currently breaking because an API doc file was left in for a function that got renamed.