### PR TITLE
add cartopy to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ numpy
 xarray
 jupyterlab
 netcdf4
+cartopy


### PR DESCRIPTION
Quickly adds `cartopy` to docs requirements. The main build is breaking right now due to a cartopy error. This might fix it.