### PR TITLE
Fix flake F401

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       rev: v2.4.0
       hooks:
       - id: flake8
-        args: ["--max-line-length=88", "--exclude=__init__.py", "--ignore=W605,W503,F722,C901,F401"]
+        args: ["--max-line-length=88", "--exclude=__init__.py", "--ignore=W605,W503,F722,C901"]
 
   -   repo: https://github.com/pre-commit/mirrors-isort
       rev: v4.3.21

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog History
 =================
 
+esmtools v1.1.2 (2020-##-##)
+============================
+
+Internals/Minor Fixes
+---------------------
+- Fix ``flake8`` F401 error by using ``TimeUtilAccessor`` directly in first instance
+  in code. (:pr:`86`) `Riley X. Brady`_.
+
 esmtools v1.1.1 (2020-07-08)
 ============================
 

--- a/ci/run-linter.sh
+++ b/ci/run-linter.sh
@@ -7,7 +7,7 @@ echo "Code Styling with (black, flake8, isort)"
 source activate esmtools-dev
 
 echo "[flake8]"
-flake8 esmtools --max-line-length=88 --exclude=__init__.py --ignore=W605,W503,F722,C901,F401
+flake8 esmtools --max-line-length=88 --exclude=__init__.py --ignore=W605,W503,F722,C901
 
 echo "[black]"
 black --check --line-length=88 -S esmtools

--- a/esmtools/stats.py
+++ b/esmtools/stats.py
@@ -53,7 +53,9 @@ def _convert_time_and_return_slope_factor(x, dim):
     """
     slope_factor = 1.0
     if isinstance(x, xr.DataArray):
-        if x.timeutils.is_temporal:
+        # Calling `TimeUtilAccessor` directly in the first case, so we don't trigger
+        # `flake8` F401 since we'd import a module but not use it.
+        if TimeUtilAccessor(x).is_temporal:
             slope_factor = x.timeutils.slope_factor
             x = x.timeutils.return_numeric_time()
     return x, slope_factor

--- a/esmtools/tests/test_timeutils.py
+++ b/esmtools/tests/test_timeutils.py
@@ -1,63 +1,65 @@
 import pandas as pd
 import pytest
 
-import esmtools
+from esmtools.timeutils import TimeUtilAccessor
 
 
 def test_timeutils_accessor(annual_gregorian):
     """Test that the `timeutils` accessor can be called."""
-    assert annual_gregorian.timeutils._obj.notnull().all()
+    # Calling the TimeUtilAccessor directly in the first instance to not trigger
+    # F401 (importing unused module) from flake8.
+    assert TimeUtilAccessor(annual_gregorian)._obj.notnull().all()
 
 
 def test_annual_factor(
     annual_all_leap, annual_no_leap, annual_gregorian, annual_julian
 ):
     """Tests that the annual factor returned by timeutils is accurate."""
-    assert annual_all_leap["time"].timeutils.annual_factor == 366.0
-    assert annual_no_leap["time"].timeutils.annual_factor == 365.0
-    assert annual_gregorian["time"].timeutils.annual_factor == 365.25
-    assert annual_julian["time"].timeutils.annual_factor == 365.25
+    assert annual_all_leap['time'].timeutils.annual_factor == 366.0
+    assert annual_no_leap['time'].timeutils.annual_factor == 365.0
+    assert annual_gregorian['time'].timeutils.annual_factor == 365.25
+    assert annual_julian['time'].timeutils.annual_factor == 365.25
 
 
 def test_calendar(annual_all_leap, annual_no_leap, annual_gregorian, annual_julian):
     """Tests that the calendar returned by timeutils is accurate."""
-    assert annual_all_leap["time"].timeutils.calendar == "all_leap"
-    assert annual_no_leap["time"].timeutils.calendar == "noleap"
-    assert annual_gregorian["time"].timeutils.calendar == "gregorian"
-    assert annual_julian["time"].timeutils.calendar == "julian"
+    assert annual_all_leap['time'].timeutils.calendar == 'all_leap'
+    assert annual_no_leap['time'].timeutils.calendar == 'noleap'
+    assert annual_gregorian['time'].timeutils.calendar == 'gregorian'
+    assert annual_julian['time'].timeutils.calendar == 'julian'
 
 
-@pytest.mark.parametrize("frequency", ("L", "D", "AS-NOV", "W-TUE"))
+@pytest.mark.parametrize('frequency', ('L', 'D', 'AS-NOV', 'W-TUE'))
 def test_freq(annual_gregorian, frequency):
     """Tests that the calendar frequency returned by timeutils is accurate."""
     data = annual_gregorian
-    data["time"] = pd.date_range("1990", freq=frequency, periods=data.time.size)
-    assert data["time"].timeutils.freq == frequency
+    data['time'] = pd.date_range('1990', freq=frequency, periods=data.time.size)
+    assert data['time'].timeutils.freq == frequency
 
 
 expected_slopes = {
-    "L": 1 / (24 * 60 * 60 * 1e3),
-    "D": 1,
-    "AS-NOV": 365.25,
-    "W-TUE": 7.0,
+    'L': 1 / (24 * 60 * 60 * 1e3),
+    'D': 1,
+    'AS-NOV': 365.25,
+    'W-TUE': 7.0,
 }
 
 
-@pytest.mark.parametrize("frequency", ("L", "D", "AS-NOV", "W-TUE"))
+@pytest.mark.parametrize('frequency', ('L', 'D', 'AS-NOV', 'W-TUE'))
 def test_slope_factor(annual_gregorian, frequency):
     """Tests that the slope factor returned by timeutils is accurate."""
     data = annual_gregorian
-    data["time"] = pd.date_range("1990", freq=frequency, periods=data.time.size)
-    assert data["time"].timeutils.slope_factor == expected_slopes[frequency]
+    data['time'] = pd.date_range('1990', freq=frequency, periods=data.time.size)
+    assert data['time'].timeutils.slope_factor == expected_slopes[frequency]
 
 
 def test_return_numeric_time_datetime(gridded_da_datetime):
     """Tests that datetimes are properly converted to numeric time by timeutils."""
-    data = gridded_da_datetime()["time"]
-    assert data.timeutils.return_numeric_time().dtype == "float64"
+    data = gridded_da_datetime()['time']
+    assert data.timeutils.return_numeric_time().dtype == 'float64'
 
 
 def test_return_numeric_time_cftime(gridded_da_cftime):
     """Tests that cftimes are properly converted to numeric time by timeutils."""
-    data = gridded_da_cftime()["time"]
-    assert data.timeutils.return_numeric_time().dtype == "float64"
+    data = gridded_da_cftime()['time']
+    assert data.timeutils.return_numeric_time().dtype == 'float64'

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [flake8]
 exclude = docs
-ignore = E203,E266,E501,W503,F401,W605,E402
+ignore = E203,E266,E501,W503,W605,E402
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
# Description

Quick fix to `flake8` F401 error (importing unused module). Just wrapping first instance of timeutil accessor with `TimeUtilAccessor` so the imported class is actually used.