### PR TITLE
Remove custom exceptions

### DIFF
--- a/esmtools/accessor.py
+++ b/esmtools/accessor.py
@@ -3,8 +3,8 @@ import xarray as xr
 from .grid import convert_lon
 
 
-@xr.register_dataarray_accessor("grid")
-@xr.register_dataset_accessor("grid")
+@xr.register_dataarray_accessor('grid')
+@xr.register_dataset_accessor('grid')
 class GridAccessor:
     """Allows functions to be called directly on an xarray dataset for the grid module.
 
@@ -14,7 +14,7 @@ class GridAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
 
-    def convert_lon(self, coord="lon"):
+    def convert_lon(self, coord='lon'):
         """Converts longitude grid from -180to180 to 0to360 and vice versa.
 
         .. note::
@@ -29,6 +29,6 @@ class GridAccessor:
             xarray object: Dataset with converted longitude grid.
 
         Raises:
-            CoordinateError: If ``coord`` does not exist in the dataset.
+            ValueError: If ``coord`` does not exist in the dataset.
         """
         return convert_lon(self._obj, coord=coord)

--- a/esmtools/checks.py
+++ b/esmtools/checks.py
@@ -3,8 +3,6 @@ from functools import wraps
 import numpy as np
 import xarray as xr
 
-from .exceptions import DimensionError
-
 
 def has_missing(data):
     """Returns ``True`` if any NaNs in ``data`` and ``False`` otherwise.
@@ -36,9 +34,9 @@ def has_dims(xobj, dims, kind):
         dims = [dims]
 
     if not all(dim in xobj.dims for dim in dims):
-        raise DimensionError(
-            f"Your {kind} object must contain the "
-            f"following dimensions at the minimum: {dims}"
+        raise ValueError(
+            f'Your {kind} object must contain the '
+            f'following dimensions at the minimum: {dims}'
         )
     return True
 

--- a/esmtools/grid.py
+++ b/esmtools/grid.py
@@ -1,9 +1,8 @@
 from .checks import is_xarray
-from .exceptions import CoordinateError
 
 
 @is_xarray(0)
-def _convert_lon_to_180to180(ds, coord="lon"):
+def _convert_lon_to_180to180(ds, coord='lon'):
     """Convert from 0 to 360 (degrees E) grid to -180 to 180 (W-E) grid.
 
     .. note::
@@ -28,7 +27,7 @@ def _convert_lon_to_180to180(ds, coord="lon"):
 
 
 @is_xarray(0)
-def _convert_lon_to_0to360(ds, coord="lon"):
+def _convert_lon_to_0to360(ds, coord='lon'):
     """Convert from -180 to 180 (W-E) to 0 to 360 (degrees E) grid.
 
     .. note::
@@ -55,7 +54,7 @@ def _convert_lon_to_0to360(ds, coord="lon"):
 # NOTE: Check weird POP grid that goes up to 240 or something. How do we deal with
 # that?
 @is_xarray(0)
-def convert_lon(ds, coord="lon"):
+def convert_lon(ds, coord='lon'):
     """Converts longitude grid from -180to180 to 0to360 and vice versa.
 
     .. note::
@@ -70,7 +69,7 @@ def convert_lon(ds, coord="lon"):
         xarray object: Dataset with converted longitude grid.
 
     Raises:
-        CoordinateError: If ``coord`` does not exist in the dataset.
+        ValueError: If ``coord`` does not exist in the dataset.
 
     Examples:
        >>> import numpy as np
@@ -87,7 +86,7 @@ def convert_lon(ds, coord="lon"):
        >>> converted = convert_lon(data, coord='lon')
     """
     if coord not in ds.coords:
-        raise CoordinateError(f"{coord} not found in coordinates.")
+        raise ValueError(f'{coord} not found in coordinates.')
     if ds[coord].min() < 0:
         ds = _convert_lon_to_0to360(ds, coord=coord)
     else:

--- a/esmtools/tests/test_grid.py
+++ b/esmtools/tests/test_grid.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from esmtools.exceptions import CoordinateError
 from esmtools.grid import convert_lon
 
 
@@ -23,13 +22,13 @@ def da_1D():
         elif not degreesEast:
             lon = np.linspace(-179.5, 179.5, 360)
         else:
-            raise ValueError("Please specify `degreesEast` as either True or False.")
+            raise ValueError('Please specify `degreesEast` as either True or False.')
         # Template for broadcasting to
         empty = xr.DataArray(
-            np.empty((180, 360)), dims=["lat", "lon"], coords=[lat, lon]
+            np.empty((180, 360)), dims=['lat', 'lon'], coords=[lat, lon]
         )
         # Data is roughly the longitude at each grid cell.
-        data = xr.DataArray(np.linspace(-180, 180, 360), dims=["lon"], coords=[lon])
+        data = xr.DataArray(np.linspace(-180, 180, 360), dims=['lon'], coords=[lon])
         # Simple broadcasting up to 180x360 dimensions.
         data, _ = xr.broadcast(data, empty)
         data = data.T
@@ -55,19 +54,19 @@ def da_2D():
         elif not degreesEast:
             x = np.linspace(-179.5, 179.5, 360)
         else:
-            raise ValueError("Please specify `degreesEast` as either True or False.")
+            raise ValueError('Please specify `degreesEast` as either True or False.')
         # Meshgrid into a 2-dimensional lon/lat.
         lon, lat = np.meshgrid(x, y)
         # Template for broadcasting to
-        empty = xr.DataArray(np.empty((180, 360)), dims=["y", "x"])
+        empty = xr.DataArray(np.empty((180, 360)), dims=['y', 'x'])
         # Data is roughly the longitude at each grid cell.
-        data = xr.DataArray(np.linspace(-180, 180, 360), dims=["x"])
+        data = xr.DataArray(np.linspace(-180, 180, 360), dims=['x'])
         # Simple broadcasting up to 180x360 dimensions.
         data, _ = xr.broadcast(data, empty)
         data = data.T
         # Add 2D coordinates.
-        data["lon"] = (("y", "x"), lon)
-        data["lat"] = (("y", "x"), lat)
+        data['lon'] = (('y', 'x'), lon)
+        data['lat'] = (('y', 'x'), lat)
         return data
 
     return _gen_data
@@ -127,7 +126,7 @@ def test_coordinate_error(da_1D):
     """Tests that coordinate error is thrown when convert_lon is called and the
     coordinate doesn't exist."""
     data = da_1D(degreesEast=True)
-    with pytest.raises(CoordinateError) as e:
+    with pytest.raises(ValueError) as e:
         # Purposefully call nonexistant coordinate.
-        convert_lon(data, coord="foo")
-    assert "not found in coordinates" in str(e.value)
+        convert_lon(data, coord='foo')
+    assert 'not found in coordinates' in str(e.value)


### PR DESCRIPTION
Removes custom exceptions `DimensionError` and `CoordinateError`. This is probably bad practice for a base package like this. It makes it hard to anticipate certain errors, as encountered in https://github.com/bradyrx/climpred/pull/395. For `climpred` classes, I anticipate errors when looping through datasets in our objects. We should just be able to do `try/except` with `ValueError` and `KeyError` without importing the `esmtools` `DimensionError`.