### PR TITLE
upgrade setup_miniconda to v2

### DIFF
--- a/.github/workflows/esmtools_testing.yml
+++ b/.github/workflows/esmtools_testing.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           channels: conda-forge


### PR DESCRIPTION
# Description

Upgrades `setup-miniconda` to v2 to fix bug introduced by Github Actions update.

Fixes # https://github.com/bradyrx/esmtools/issues/104

See https://github.com/conda-incubator/setup-miniconda/issues/99 and https://github.com/conda-incubator/setup-miniconda/issues/101.
